### PR TITLE
3-7-spring-boot-service-cp

### DIFF
--- a/build-logic/src/main/kotlin/chirp.spring-boot-service.gradle.kts
+++ b/build-logic/src/main/kotlin/chirp.spring-boot-service.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("chirp.kotlin-common")
-    id("org.spring.framework.boot")
+    id("org.springframework.boot")
     id("io.spring.dependency-management")
 }
 

--- a/build-logic/src/main/kotlin/chirp.sprint-boot-service.gradle.kts
+++ b/build-logic/src/main/kotlin/chirp.sprint-boot-service.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id("chirp.kotlin-common")
+    id("org.spring.framework.boot")
+    id("io.spring.dependency-management")
+}
+
+dependencies {
+    "implementation"(libraries.findLibrary("kotlin-reflect").get())
+    "implementation"(libraries.findLibrary("kotlin-stdlib").get())
+    "implementation"(libraries.findLibrary("spring-boot-starter-web").get())
+
+    "testImplementation"(libraries.findLibrary("spring-boot-starter-test").get())
+    "testImplementation"(libraries.findLibrary("kotlin-test-junit5").get())
+    "testRuntimeOnly"(libraries.findLibrary("junit-platform-launcher").get())
+}

--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -1,9 +1,7 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.kotlin.jpa)
-    alias(libs.plugins.spring.boot)
-    alias(libs.plugins.spring.dependency.management)
-    alias(libs.plugins.kotlin.spring)
+    id("java-library")
+    id("chirp.spring-boot-service")
+    kotlin("plugin.jpa")
 }
 
 group = "com.mmunoz"

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,9 +1,7 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.kotlin.jpa)
-    alias(libs.plugins.spring.boot)
-    alias(libs.plugins.spring.dependency.management)
-    alias(libs.plugins.kotlin.spring)
+    id("java-library")
+    id("chirp.kotlin-common")
+    id("org.springframework.boot")
 }
 
 group = "com.mmunoz"

--- a/notification/build.gradle.kts
+++ b/notification/build.gradle.kts
@@ -1,9 +1,7 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.kotlin.jpa)
-    alias(libs.plugins.spring.boot)
-    alias(libs.plugins.spring.dependency.management)
-    alias(libs.plugins.kotlin.spring)
+    id("java-library")
+    id("chirp.spring-boot-service")
+    kotlin("plugin.jpa")
 }
 
 group = "com.mmunoz"

--- a/user/build.gradle.kts
+++ b/user/build.gradle.kts
@@ -1,9 +1,7 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.kotlin.jpa)
-    alias(libs.plugins.spring.boot)
-    alias(libs.plugins.spring.dependency.management)
-    alias(libs.plugins.kotlin.spring)
+    id("java-library")
+    id("chirp.spring-boot-service")
+    kotlin("plugin.jpa")
 }
 
 group = "com.mmunoz"


### PR DESCRIPTION
Applied the new gradle convention plugin for sprint boot service gradle file also fixed some typos 
this plugin was applied to the next modules:
Chat
Notification
User

Chirp Common plugin convention was applied to common module 

Note: chirp.spring-boot-service includes "chirp.kotlin-common" plugin convention